### PR TITLE
Update 13-change-feed.md

### DIFF
--- a/instructions/13-change-feed.md
+++ b/instructions/13-change-feed.md
@@ -134,12 +134,15 @@ The **Microsoft.Azure.Cosmos.Container** class ships with a series of methods to
 
 1. Create a new delegate variable named **handleChanges** of type [ChangesHandler<>][docs.microsoft.com/dotnet/api/microsoft.azure.cosmos.container.changefeedhandler-1] using an empty asynchronous anonymous function that has two input parameters:
 
+    1. A parameter named **context** of type **ChangeFeedProcessorContext**.
+
     1. A parameter named **changes** of type **IReadOnlyCollection\<Product\>**.
 
     1. A parameter named **cancellationToken** of type **CancellationToken**.
 
     ```
     ChangesHandler<Product> handleChanges = async (
+        ChangeFeedProcessorContext context,
         IReadOnlyCollection<Product> changes, 
         CancellationToken cancellationToken
     ) => {
@@ -224,6 +227,7 @@ The **Microsoft.Azure.Cosmos.Container** class ships with a series of methods to
     Container leaseContainer = client.GetContainer("cosmicworks", "productslease");
     
     ChangesHandler<Product> handleChanges = async (
+        ChangeFeedProcessorContext context,
         IReadOnlyCollection<Product> changes, 
         CancellationToken cancellationToken
     ) => {


### PR DESCRIPTION
The handler has another parameter useful for users to log extra information,

# Module: 13
## Lab/Demo: 13

Fixes # .

- Change Feed Processor handler includes the context, which contains extra information. Ideally we want to promote this as it aligns with the official CFP docs: https://docs.microsoft.com/en-us/azure/cosmos-db/sql/change-feed-processor#implementing-the-change-feed-processor