### PR TITLE
Fix RU/s typo in 16-measure-performance

### DIFF
--- a/instructions/16-measure-performance.md
+++ b/instructions/16-measure-performance.md
@@ -137,6 +137,6 @@ Now we're going to query for the same information but with the entities embedded
 
 When you compare the RU/s for each query that you ran, you see that the last query where the customer entities are in a single document is much less expensive than the combined cost for running the three queries independently. The latency for returning this data is lower because the data is returned in a single operation.
 
-When you're searching for a single item and know the partition key and ID of the data, you can retrieve this data via a *point-read* by calling `ReadItemAsync()` in the Azure Cosmos DB SDK. A point-read is even faster than our query. For the same customer data, the cost is just 1 RU/s, which is a nearly threefold improvement.
+When you're searching for a single item and know the partition key and ID of the data, you can retrieve this data via a *point-read* by calling `ReadItemAsync()` in the Azure Cosmos DB SDK. A point-read is even faster than our query. For the same customer data, the cost is just 1 RU, which is a nearly threefold improvement.
 
 [code.visualstudio.com/docs/getstarted]: https://code.visualstudio.com/docs/getstarted/tips-and-tricks


### PR DESCRIPTION
See the small change.

As far as I know, RU/s is a throughput metric, and the RU is the metric for referring the cost of discrete operations.

Examples:
- the point read costs `1 RU` (1 request unit)
- a pricier point read costs `4.76 RUs` (4.76 request unit**s**)
- if I run the cheapest point read (1 RU) every second, this results in a `1 RU/s` load (requests per unit).