### PR TITLE
Update `cosmicworks` installation command

### DIFF
--- a/instructions/03-migrate-data.md
+++ b/instructions/03-migrate-data.md
@@ -55,7 +55,7 @@ To accompany the products container, you will create a **flatproducts** containe
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.

--- a/instructions/09-sdk-queries.md
+++ b/instructions/09-sdk-queries.md
@@ -68,7 +68,7 @@ The [cosmicworks][nuget.org/packages/cosmicworks] command-line tool deploys samp
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.

--- a/instructions/10-sdk-pagination.md
+++ b/instructions/10-sdk-pagination.md
@@ -66,7 +66,7 @@ The [cosmicworks][nuget.org/packages/cosmicworks] command-line tool deploys samp
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.

--- a/instructions/11-default-indexing-policy.md
+++ b/instructions/11-default-indexing-policy.md
@@ -55,7 +55,7 @@ The [cosmicworks][nuget.org/packages/cosmicworks] command-line tool deploys samp
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
   
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.

--- a/instructions/13-change-feed.md
+++ b/instructions/13-change-feed.md
@@ -276,7 +276,7 @@ You will use a command-line utility that creates a **cosmicworks** database and 
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.

--- a/instructions/14-functions.md
+++ b/instructions/14-functions.md
@@ -217,7 +217,7 @@ You will use a command-line utility that creates a **cosmicworks** database and 
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.

--- a/instructions/15-cognitive-search.md
+++ b/instructions/15-cognitive-search.md
@@ -65,7 +65,7 @@ You will use a command-line utility that creates a **cosmicworks** database and 
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.

--- a/instructions/24-query-optimization.md
+++ b/instructions/24-query-optimization.md
@@ -65,7 +65,7 @@ You will use a command-line utility that creates a **cosmicworks** database and 
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.

--- a/instructions/33-create-use-udf-sdk.md
+++ b/instructions/33-create-use-udf-sdk.md
@@ -66,7 +66,7 @@ The [cosmicworks][nuget.org/packages/cosmicworks] command-line tool deploys samp
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install --global cosmicworks
+    dotnet tool install cosmicworks --global --version 1.*
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.


### PR DESCRIPTION
# Module: Multiple
## Lab/Demo: 03, 09, 10, 11, 13, 14, 15, 24, 33

Changes proposed in this pull request:

- Update [CosmicWorks]() CLI installation command to future-proof against version 2.x launching soon.
  - Old command: `dotnet tool install --global cosmicworks` (*This command will break the labs when 2.x launches because it always installs the latest version.*)
  - New command: `dotnet tool install cosmicworks --global --version 1.*` (*This command will never install a version > 1.x*)