### PR TITLE
Update CosmicWorks version and associated syntax changes

### DIFF
--- a/instructions/03-migrate-data.md
+++ b/instructions/03-migrate-data.md
@@ -40,9 +40,7 @@ To accompany the products container, you will create a **flatproducts** containe
 
 1. This pane contains the connection details and credentials necessary to connect to the account from the SDK. Specifically:
 
-    1. Notice the **URI** field. You will use this **endpoint** value later in this exercise.
-
-    1. Notice the **PRIMARY KEY** field. You will use this **key** value later in this exercise.
+    1. Notice the **PRIMARY CONNECTION STRING** field. You will use this **connection string** value later in this exercise.
 
 1. Keep the browser tab open, as we will return to it later.
 
@@ -55,7 +53,7 @@ To accompany the products container, you will create a **flatproducts** containe
 1. Install the [cosmicworks][nuget.org/packages/cosmicworks] command-line tool for global use on your machine.
 
     ```
-    dotnet tool install cosmicworks --global --version 1.*
+    dotnet tool install --global CosmicWorks --version 2.3.1
     ```
 
     > &#128161; This command may take a couple of minutes to complete. This command will output the warning message (*Tool 'cosmicworks' is already installed') if you have already installed the latest version of this tool in the past.
@@ -64,16 +62,16 @@ To accompany the products container, you will create a **flatproducts** containe
 
     | **Option** | **Value** |
     | ---: | :--- |
-    | **--endpoint** | *The endpoint value you checked earlier in this lab* |
-    | **--key** | *The key value you checked earlier in this lab* |
-    | **--datasets** | *product* |
+    | **--connection-string** | *The connection string value you checked earlier in this lab* |
+    | **--number-of-products** | *1000* |
+    | **--number-of-employees** | *0* |
 
     ```
-    cosmicworks --endpoint <cosmos-endpoint> --key <cosmos-key> --datasets product
+    cosmicworks --connection-string "<cosmos-connection-string>" --number-of-products 1000 --number-of-employees 0 --disable-hierarchical-partition-keys
     ```
 
-    > &#128221; For example, if your endpoint is: **https&shy;://dp420.documents.azure.com:443/** and your key is: **fDR2ci9QgkdkvERTQ==**, then the command would be:
-    > ``cosmicworks --endpoint https://dp420.documents.azure.com:443/ --key fDR2ci9QgkdkvERTQ== --datasets product``
+    > &#128221; For example, if your connection string is: **AccountEndpoint=https&shy;://dp420.documents.azure.com:443/;AccountKey=fDR2ci9QgkdkvERTQ==;**, then the command would be:
+    > ``cosmicworks --connection-string "AccountEndpoint=https://dp420.documents.azure.com:443/;AccountKey=fDR2ci9QgkdkvERTQ==;" --number-of-products 1000 --number-of-employees 0 --disable-hierarchical-partition-keys``
 
 1. Wait for the **cosmicworks** command to finish populating the account with a database, container, and items.
 
@@ -89,7 +87,7 @@ To accompany the products container, you will create a **flatproducts** containe
 
 1. Observe and select the various JSON items in the **products** container. These are the items created by the command-line tool used in previous steps.
 
-1. Select the **Scale & Settings** node. In the **Scale & Settings** tab, select **Manual**, update the **required throughput** setting from **4000 RU/s** to **400 RU/s** and then **Save** your changes**.
+1. Select the **Scale** node under the **cosmicworks** database node. In the **Scale** tab, update the **Throughput** setting from **4000 RU/s** to **400 RU/s** and then **Save** your changes**.
 
 1. In the **Data Explorer** pane, select **New Container**.
 
@@ -100,8 +98,6 @@ To accompany the products container, you will create a **flatproducts** containe
     | **Database id** | *Use existing* &vert; *cosmicworks* |
     | **Container id** | *`flatproducts`* |
     | **Partition key** | *`/category`* |
-    | **Container throughput (autoscale)** | *Manual* |
-    | **RU/s** | *`400`* |
 
 1. Back in the **Data Explorer** pane, expand the **cosmicworks** database node and then observe the **flatproducts** container node within the hierarchy.
 


### PR DESCRIPTION
Updating CosmicWorks version as previous one no longer works due to changes in the repo. New version has some syntax changes with how the command is called and what's created by default, so updating the guide to reflect these.

# Module: dp-420
## Lab/Demo: 03

Changes proposed in this pull request:

- Updated install command for CosmicWorks library
- Changed requirement from endpoint/key to connection-string
- Changed dataset to number of records per dataset and disable default creation of hierarchical partitioned containers
- CosmicWorks library now creates a shared throughput database; removed references to container-level throughput