### PR TITLE
brought ex 16 and 17 up to .NET 8

### DIFF
--- a/16-measure-performance/modeling.csproj
+++ b/16-measure-performance/modeling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.49.0" />

--- a/17-denormalize/modeling.csproj
+++ b/17-denormalize/modeling.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.49.0" />


### PR DESCRIPTION
# Modules: "Implement a Non-Relational Data Model" and "Design a Data Partitioning Strategy"
## Labs 16 and 17

Fixes #72 .

Brings exercises 16 and 17 up to .NET 8, matching the other projects in the repo.

(While an argument could be made to bring *all* exercises up to the new LTS which is .NET 10, that is a larger change that should be pursued separately in case there are breaking changes. This PR merely makes exercises 16 and 17 consistent with the rest of the repository. I have tested that these projects still work after these changes)

