### PR TITLE
added instructions to add Newtonsoft to ex 26

### DIFF
--- a/instructions/26-sdk-troubleshoot.md
+++ b/instructions/26-sdk-troubleshoot.md
@@ -75,6 +75,12 @@ The .NET CLI includes an [add package][docs.microsoft.com/dotnet/core/tools/dotn
     dotnet add package Microsoft.Azure.Cosmos --version 3.49.0
     ```
 
+1. Add the [Newtonsoft.Json][nuget.org/packages/Newtonsoft.Json/13.0.3] package from NuGet using the following command:
+
+    ```
+    dotnet add package Newtonsoft.Json --version 13.0.3
+    ```
+
 ## Run a script to create menu-driven options to insert and delete documents.
 
 Before we can run our application, we need to connect it to our Azure Cosmos DB account. 


### PR DESCRIPTION
# Module: Troubleshoot an application using the Azure Cosmos DB for NoSQL SDK
## Lab/Demo: 26

Fixes #74.

Adds instructions telling the user how to add the Newtonsoft package to the project.

(As a side note, most other csprojs in this repo already have both the Cosmos *and* Newtonsoft packages installed despite also explicitly telling the user to install one or both, unlike 26 which has neither installed out of the box, but that inconsistency is a different issue for a different time)